### PR TITLE
docs bug syntax change

### DIFF
--- a/website/source/docs/modules/sources.html.markdown
+++ b/website/source/docs/modules/sources.html.markdown
@@ -157,7 +157,7 @@ URLs for Mercurial repositories support the following query parameters:
 
 ```
 module "consul" {
-  source = "hg::http://hashicorp.com/consul.hg?ref=master"
+  source = "hg::http://hashicorp.com/consul.hg?rev=default"
 }
 ```
 


### PR DESCRIPTION
rev vs ref in docs.

the default branch on hg is default, not master.